### PR TITLE
Remove unused header

### DIFF
--- a/exampleStreamSimple/src/ofApp.h
+++ b/exampleStreamSimple/src/ofApp.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "ofMain.h"
-#include "ofxProfiler.h"
 #include "ofxSquash.h"
 
 class ofApp : public ofBaseApp{


### PR DESCRIPTION
Example references a header that's not used/required.
