### PR TITLE
Add addon_config.mk so that OSX project generator works.

### DIFF
--- a/addon_config.mk
+++ b/addon_config.mk
@@ -1,0 +1,10 @@
+meta:
+	ADDON_NAME = ofxSquash
+	ADDON_DESCRIPTION = Compress and decompress data using a large range of compression codecs supplied by libsquash
+	ADDON_AUTHOR = Elliot Woods
+	ADDON_URL = https://github.com/elliotwoods/ofxSquash
+
+common:
+	ADDON_INCLUDES = libs/squash/include
+	ADDON_INCLUDES += src
+	ADDON_LIBS_EXCLUDE = libs/squash/bin/%


### PR DESCRIPTION
[OSX] 
Current implementation unexpectedly links to *.dylib in Xcode project when project generator is used. To avoid it, addon_config.mk is added.
I'm not sure "meta:" section is appropriate and I didn't test on Windows environment.
Please modify them if needed. Thanks.